### PR TITLE
Enforced stricter coding standards, and did small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - 7.1
   - 7.2
-  - hhvm
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 
 sudo: false
@@ -17,6 +17,7 @@ script:
   - ./vendor/bin/phpunit --coverage-text
   - ./vendor/bin/phpcs src --standard=psr2 -sp
   - ./vendor/infection/infection/bin/infection --threads=4 --min-covered-msi=50
+  - ./vendor/bin/phpcs src --standard=phpcs.ruleset.xml
   - ./vendor/phpstan/phpstan/bin/phpstan analyze src --level=3
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ before_script:
 script:
   - mkdir -p build/logs
   - ./vendor/bin/phpunit --coverage-text
-  - ./vendor/bin/phpcs src --standard=psr2 -sp
-  - ./vendor/infection/infection/bin/infection --threads=4 --min-covered-msi=50
   - ./vendor/bin/phpcs src --standard=phpcs.ruleset.xml
   - ./vendor/phpstan/phpstan/bin/phpstan analyze src --level=3
+  - ./vendor/infection/infection/bin/infection --threads=4 --min-covered-msi=50
 
 after_script:
   - php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - ./vendor/bin/phpunit --coverage-text
   - ./vendor/bin/phpcs src --standard=psr2 -sp
   - ./vendor/infection/infection/bin/infection --threads=4 --min-covered-msi=50
+  - ./vendor/phpstan/phpstan/bin/phpstan analyze src --level=3
 
 after_script:
   - php vendor/bin/coveralls

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0.0",
         "guzzlehttp/guzzle": "~6.0",
         "symfony/console": "^2.5 || ^3.0 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "mockery/mockery": "~0.9",
         "squizlabs/php_codesniffer": "~3.0",
         "satooshi/php-coveralls": "0.6.*",
-        "phpstan/phpstan": "^0.10.3"
+        "phpstan/phpstan": "^0.10.3",
+        "infection/infection": "^0.10.5"
     },
     "autoload": {
         "psr-4": {
@@ -36,7 +37,8 @@
         "test": [
             "./vendor/bin/phpunit --coverage-text",
             "./vendor/bin/phpcs src --standard=phpcs.ruleset.xml",
-            "./vendor/phpstan/phpstan/bin/phpstan analyze src --level=3"
+            "./vendor/phpstan/phpstan/bin/phpstan analyze src --level=3",
+            "./vendor/infection/infection/bin/infection --threads=4 --min-covered-msi=50"
         ]
     },
     "minimum-stability": "stable"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "guzzlehttp/guzzle": "~6.0",
         "symfony/console": "^2.5 || ^3.0 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
-        "squizlabs/php_codesniffer": "~3.0",
+        "squizlabs/php_codesniffer": "~3.3",
         "satooshi/php-coveralls": "0.6.*",
         "phpstan/phpstan": "^0.10.3",
         "infection/infection": "^0.10.5"

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
-        "squizlabs/php_codesniffer": "~2.0",
+        "squizlabs/php_codesniffer": "~3.0",
         "satooshi/php-coveralls": "0.6.*",
-        "infection/infection": "^0.10.5"
+        "phpstan/phpstan": "^0.10.3"
     },
     "autoload": {
         "psr-4": {
@@ -31,6 +31,13 @@
         "psr-4": {
             "PCextreme\\Cloudstack\\Test\\": "test/src/"
         }
+    },
+    "scripts": {
+        "test": [
+            "./vendor/bin/phpunit --coverage-text",
+            "./vendor/bin/phpcs src --standard=phpcs.ruleset.xml",
+            "./vendor/phpstan/phpstan/bin/phpstan analyze src --level=3"
+        ]
     },
     "minimum-stability": "stable"
 }

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="PCextreme">
+    <description>Coding standard.</description>
+
+    <arg name="report" value="full,summary"/>
+    <arg name="colors"/>
+    <arg value="p"/>
+
+    <rule ref="PSR1" />
+    <rule ref="PSR2" />
+
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
+    </rule>
+    <rule ref="Squiz.Commenting.VariableComment" />
+
+    <rule ref="Generic.Files.LineLength">
+        <exclude name="Generic.Files.LineLength.TooLong" />
+    </rule>
+</ruleset>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -8,6 +8,7 @@
 
     <rule ref="PSR1" />
     <rule ref="PSR2" />
+    <rule ref="PSR12" />
 
     <rule ref="Squiz.Commenting.FunctionComment">
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -35,9 +35,9 @@ abstract class AbstractClient
     /**
      * Constructs a new Cloudstack client instance.
      *
-     * @param  array  $options
+     * @param  array $options
      *     An array of options to set on this client.
-     * @param  array  $collaborators
+     * @param  array $collaborators
      *     An array of collaborators that may be used to override
      *     this provider's default behavior. Collaborators include
      *     `requestFactory` and `httpClient`.
@@ -62,7 +62,7 @@ abstract class AbstractClient
     /**
      * Return the list of options that can be passed to the HttpClient
      *
-     * @param  array  $options
+     * @param  array $options
      * @return array
      */
     protected function getAllowedClientOptions(array $options)
@@ -80,12 +80,12 @@ abstract class AbstractClient
     /**
      * Returns a PSR-7 request instance that is not authenticated.
      *
-     * @param  string  $method
-     * @param  string  $url
-     * @param  array   $options
+     * @param  string $method
+     * @param  string $url
+     * @param  array  $options
      * @return RequestInterface
      */
-    public function getRequest($method, $url, array $options = [])
+    public function getRequest(string $method, string $url, array $options = [])
     {
         return $this->createRequest($method, $url, $options);
     }
@@ -93,12 +93,12 @@ abstract class AbstractClient
     /**
      * Creates a PSR-7 request instance.
      *
-     * @param  string  $method
-     * @param  string  $url
-     * @param  array   $options
+     * @param  string $method
+     * @param  string $url
+     * @param  array  $options
      * @return RequestInterface
      */
-    protected function createRequest($method, $url, array $options)
+    protected function createRequest(string $method, string $url, array $options)
     {
         $factory = $this->getRequestFactory();
 
@@ -108,7 +108,7 @@ abstract class AbstractClient
     /**
      * Sends a request instance and returns a response instance.
      *
-     * @param  RequestInterface  $request
+     * @param  RequestInterface $request
      * @return ResponseInterface
      */
     protected function sendRequest(RequestInterface $request)
@@ -125,7 +125,7 @@ abstract class AbstractClient
     /**
      * Sends a request and returns the parsed response.
      *
-     * @param  RequestInterface  $request
+     * @param  RequestInterface $request
      * @return mixed
      */
     public function getResponse(RequestInterface $request)
@@ -141,11 +141,11 @@ abstract class AbstractClient
     /**
      * Attempts to parse a JSON response.
      *
-     * @param  string  $content
+     * @param  string $content
      * @return array
      * @throws UnexpectedValueException
      */
-    protected function parseJson($content)
+    protected function parseJson(string $content)
     {
         $content = json_decode($content, true);
 
@@ -162,7 +162,7 @@ abstract class AbstractClient
     /**
      * Returns the content type header of a response.
      *
-     * @param  ResponseInterface  $response
+     * @param  ResponseInterface $response
      * @return string
      */
     protected function getContentType(ResponseInterface $response)
@@ -173,8 +173,8 @@ abstract class AbstractClient
     /**
      * Parses the response according to its content-type header.
      *
-     * @param  ResponseInterface  $response
-     * @return array
+     * @param  ResponseInterface $response
+     * @return mixed
      * @throws UnexpectedValueException
      */
     protected function parseResponse(ResponseInterface $response)
@@ -204,17 +204,17 @@ abstract class AbstractClient
     /**
      * Checks a provider response for errors.
      *
-     * @param  ResponseInterface  $response
-     * @param  array|string       $data
+     * @param  ResponseInterface $response
+     * @param  array|string      $data
      * @return void
-     * @throws \PCextreme\Cloudstack\Exceptions\ClientException
+     * @throws \PCextreme\Cloudstack\Exception\ClientException
      */
     abstract protected function checkResponse(ResponseInterface $response, $data);
 
     /**
      * Sets the request factory instance.
      *
-     * @param  RequestFactory  $factory
+     * @param  RequestFactory $factory
      * @return self
      */
     public function setRequestFactory(RequestFactory $factory)
@@ -237,7 +237,7 @@ abstract class AbstractClient
     /**
      * Sets the HTTP client instance.
      *
-     * @param  HttpClientInterface  $client
+     * @param  HttpClientInterface $client
      * @return self
      */
     public function setHttpClient(HttpClientInterface $client)

--- a/src/Client.php
+++ b/src/Client.php
@@ -58,18 +58,18 @@ class Client extends AbstractClient
     private $responseCode = 'errorcode';
 
     /**
-     * @var bool
+     * @var boolean
      */
     private $ssoEnabled = false;
 
     /**
      * Constructs a new Cloudstack client instance.
      *
-     * @param  array  $options
+     * @param  array $options
      *     An array of options to set on this client. Options include
      *     'apiList', 'urlApi', 'urlClient', 'urlConsole', 'apiKey',
      *     'secretKey', 'responseError' and 'responseCode'.
-     * @param  array  $collaborators
+     * @param  array $collaborators
      *     An array of collaborators that may be used to override
      *     this provider's default behavior. Collaborators include
      *     `requestFactory` and `httpClient`.
@@ -125,7 +125,7 @@ class Client extends AbstractClient
     /**
      * Verifies that all required options have been passed.
      *
-     * @param  array  $options
+     * @param  array $options
      * @return void
      * @throws InvalidArgumentException
      */
@@ -140,7 +140,14 @@ class Client extends AbstractClient
         }
     }
 
-    public function command($command, array $options = [])
+    /**
+     * Execute command.
+     *
+     * @param  string $command
+     * @param  array  $options
+     * @return mixed
+     */
+    public function command(string $command, array $options = [])
     {
         $this->assertRequiredCommandOptions($command, $options);
 
@@ -154,12 +161,13 @@ class Client extends AbstractClient
     /**
      * Verifies that all required options have been passed.
      *
-     * @param  array $options
+     * @param string $command
+     * @param  array  $options
      * @return void
      * @throws RuntimeException
      * @throws InvalidArgumentException
      */
-    private function assertRequiredCommandOptions($command, array $options = [])
+    private function assertRequiredCommandOptions(string $command, array $options = [])
     {
         $apiList = $this->getApiList();
 
@@ -181,10 +189,10 @@ class Client extends AbstractClient
     /**
      * Returns command method based on the command.
      *
-     * @param  string  $command
-     * @return array
+     * @param  string $command
+     * @return string
      */
-    public function getCommandMethod($command)
+    public function getCommandMethod(string $command)
     {
         if (in_array($command, ['login', 'deployVirtualMachine'])) {
             return self::METHOD_POST;
@@ -196,7 +204,7 @@ class Client extends AbstractClient
     /**
      * Builds the command URL's query string.
      *
-     * @param  array  $params
+     * @param  array $params
      * @return string
      */
     public function getCommandQuery(array $params)
@@ -207,11 +215,11 @@ class Client extends AbstractClient
     /**
      * Builds the authorization URL.
      *
-     * @param  string  $command
-     * @param  array   $options
+     * @param  string $command
+     * @param  array  $options
      * @return string
      */
-    public function getCommandUrl($command, array $options = [])
+    public function getCommandUrl(string $command, array $options = [])
     {
         $base   = $this->urlApi;
         $params = $this->getCommandParameters($command, $options);
@@ -223,11 +231,11 @@ class Client extends AbstractClient
     /**
      * Returns command parameters based on provided options.
      *
-     * @param  string  $command
-     * @param  array   $options
+     * @param  string $command
+     * @param  array  $options
      * @return array
      */
-    protected function getCommandParameters($command, array $options)
+    protected function getCommandParameters(string $command, array $options)
     {
         return array_merge($options, [
             'command'  => $command,
@@ -239,8 +247,8 @@ class Client extends AbstractClient
     /**
      * Signs the command parameters.
      *
-     * @param  array  $params
-     * @return array
+     * @param  array $params
+     * @return string
      */
     protected function signCommandParameters(array $params = [])
     {
@@ -299,7 +307,7 @@ class Client extends AbstractClient
     /**
      * Set Cloudstack Client API list.
      *
-     * @param  array  $apiList
+     * @param  array $apiList
      * @return void
      */
     public function setApiList(array $apiList)
@@ -310,11 +318,11 @@ class Client extends AbstractClient
     /**
      * Appends a query string to a URL.
      *
-     * @param  string  $url
-     * @param  string  $query
+     * @param  string $url
+     * @param  string $query
      * @return string
      */
-    protected function appendQuery($url, $query)
+    protected function appendQuery(string $url, string $query)
     {
         $query = trim($query, '?&');
 
@@ -328,14 +336,14 @@ class Client extends AbstractClient
     /**
      * Build a query string from an array.
      *
-     * @param  array  $params
+     * @param  array $params
      * @return string
      */
     protected function buildQueryString(array $params)
     {
         // We need to modify the nested array keys to get them accepted by Cloudstack.
         // For example 'details[0][key]' should resolve to 'details[0].key'.
-        array_walk($params, function(&$value, $key) {
+        array_walk($params, function (&$value, $key) {
             if (is_array($value)) {
                 $parsedParams = [];
 
@@ -354,7 +362,7 @@ class Client extends AbstractClient
         // to encode the values, but we can't encode the keys. This would otherwise
         // compromise the signature. Therefore we can't use http_build_query().
         $queryParams = $this->flattenParams($params);
-        array_walk($queryParams, function(&$value, $key) {
+        array_walk($queryParams, function (&$value, $key) {
             $value = $key.'='.rawurlencode($value);
         });
 
@@ -364,7 +372,7 @@ class Client extends AbstractClient
     /**
      * Flatten query params.
      *
-     * @param  array  $params
+     * @param  array $params
      * @return array
      */
     protected static function flattenParams(array $params)
@@ -385,10 +393,10 @@ class Client extends AbstractClient
     /**
      * Checks a provider response for errors.
      *
-     * @param  ResponseInterface  $response
-     * @param  array|string       $data
+     * @param  ResponseInterface $response
+     * @param  array|string      $data
      * @return void
-     * @throws \PCextreme\Cloudstack\Exceptions\ClientException
+     * @throws ClientException
      */
     protected function checkResponse(ResponseInterface $response, $data)
     {
@@ -409,10 +417,10 @@ class Client extends AbstractClient
     /**
      * Enable SSO key signing for the next request.
      *
-     * @param  bool  $enable
+     * @param  boolean $enable
      * @return self
      */
-    public function enableSso($enable = true)
+    public function enableSso(bool $enable = true)
     {
         $this->ssoEnabled = $enable;
 
@@ -421,7 +429,7 @@ class Client extends AbstractClient
     /**
      * Determine if SSO signing is enabled.
      *
-     * @return bool
+     * @return boolean
      */
     public function isSsoEnabled()
     {
@@ -431,11 +439,11 @@ class Client extends AbstractClient
     /**
      * Handle dynamic method calls into the method.
      *
-     * @param  string  $method
-     * @param  array   $parameters
+     * @param  string $method
+     * @param  array  $parameters
      * @return mixed
      */
-    public function __call($method, $parameters)
+    public function __call(string $method, array $parameters)
     {
         array_unshift($parameters, $method);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -135,7 +135,7 @@ class Client extends AbstractClient
 
         if (!empty($missing)) {
             throw new InvalidArgumentException(
-                'Required options not defined: '.implode(', ', array_keys($missing))
+                'Required options not defined: ' . implode(', ', array_keys($missing))
             );
         }
     }
@@ -275,7 +275,7 @@ class Client extends AbstractClient
 
         // To prevent the signature from being escaped we simply append
         // the signature to the previously build query.
-        return $query.'&signature='.$signature;
+        return $query . '&signature=' . $signature;
     }
 
     /**
@@ -290,7 +290,7 @@ class Client extends AbstractClient
     public function getApiList()
     {
         if (is_null($this->apiList)) {
-            $path = __DIR__.'/../cache/api_list.php';
+            $path = __DIR__ . '/../cache/api_list.php';
 
             if (!file_exists($path)) {
                 throw new RuntimeException(
@@ -327,7 +327,7 @@ class Client extends AbstractClient
         $query = trim($query, '?&');
 
         if ($query) {
-            return $url.'?'.$query;
+            return $url . '?' . $query;
         }
 
         return $url;
@@ -349,8 +349,8 @@ class Client extends AbstractClient
 
                 foreach ($value as $index => $entry) {
                     $parsedParams[] = [
-                        $key.'['.$index.']'.'.key' => $entry['key'],
-                        $key.'['.$index.']'.'.value' => $entry['value'],
+                        $key . '[' . $index . ']' . '.key' => $entry['key'],
+                        $key . '[' . $index . ']' . '.value' => $entry['value'],
                     ];
                 }
 
@@ -363,7 +363,7 @@ class Client extends AbstractClient
         // compromise the signature. Therefore we can't use http_build_query().
         $queryParams = $this->flattenParams($params);
         array_walk($queryParams, function (&$value, $key) {
-            $value = $key.'='.rawurlencode($value);
+            $value = $key . '=' . rawurlencode($value);
         });
 
         return implode('&', $queryParams);

--- a/src/Console/ApiListCommand.php
+++ b/src/Console/ApiListCommand.php
@@ -26,9 +26,9 @@ class ApiListCommand extends Command
     /**
      * Executes the current command.
      *
-     * @param  InputInterface   $input
-     * @param  OutputInterface  $output
-     * @return null|int
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -57,8 +57,8 @@ class ApiListCommand extends Command
     /**
      * Ask for URL API.
      *
-     * @param  InputInterface   $input
-     * @param  OutputInterface  $output
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
      * @return string
      */
     protected function askUrlApi(InputInterface $input, OutputInterface $output)
@@ -74,8 +74,8 @@ class ApiListCommand extends Command
     /**
      * Ask for API key.
      *
-     * @param  InputInterface   $input
-     * @param  OutputInterface  $output
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
      * @return string
      */
     protected function askApiKey(InputInterface $input, OutputInterface $output)
@@ -96,8 +96,8 @@ class ApiListCommand extends Command
     /**
      * Ask for secret key.
      *
-     * @param  InputInterface   $input
-     * @param  OutputInterface  $output
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
      * @return string
      */
     protected function askSecretKey(InputInterface $input, OutputInterface $output)
@@ -118,8 +118,8 @@ class ApiListCommand extends Command
     /**
      * Dump cache file of APIs list.
      *
-     * @param  OutputInterface  $output
-     * @param  array            $list
+     * @param  OutputInterface $output
+     * @param  array           $list
      * @return void
      */
     protected function processList(OutputInterface $output, array $list = [])

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -43,7 +43,7 @@ class Application extends BaseApplication
     protected function getDefaultCommands()
     {
         $commands = array_merge(parent::getDefaultCommands(), [
-            new ApiListCommand,
+            new ApiListCommand(),
         ]);
 
         return $commands;

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -12,12 +12,12 @@ class ClientException extends Exception
     protected $response;
 
     /**
-     * @param  string        $message
-     * @param  int           $code
-     * @param  array|string  $response
+     * @param  string       $message
+     * @param  integer      $code
+     * @param  array|string $response
      * @return void
      */
-    public function __construct($message, $code, $response)
+    public function __construct(string $message, int $code, $response)
     {
         $this->response = $response;
 

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -3,6 +3,7 @@
 namespace PCextreme\Cloudstack;
 
 use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Used to produce PSR-7 Request instances.
@@ -14,11 +15,11 @@ class RequestFactory
     /**
      * Creates a PSR-7 Request instance.
      *
-     * @param  null|string                      $method   HTTP method for the request.
-     * @param  null|string                      $uri      URI for the request.
-     * @param  array                            $headers  Headers for the message.
-     * @param  string|resource|StreamInterface  $body     Message body.
-     * @param  string                           $version  HTTP protocol version.
+     * @param  null|string                     $method  HTTP method for the request.
+     * @param  null|string                     $uri     URI for the request.
+     * @param  array                           $headers Headers for the message.
+     * @param  string|resource|StreamInterface $body    Message body.
+     * @param  string                          $version HTTP protocol version.
      * @return Request
      */
     public function getRequest(
@@ -26,7 +27,7 @@ class RequestFactory
         $uri,
         array $headers = [],
         $body = null,
-        $version = '1.1'
+        string $version = '1.1'
     ) {
         return new Request($method, $uri, $headers, $body, $version);
     }
@@ -34,7 +35,7 @@ class RequestFactory
     /**
      * Parses simplified options.
      *
-     * @param  array  $options
+     * @param  array $options
      * @return array
      */
     protected function parseOptions(array $options)
@@ -52,9 +53,9 @@ class RequestFactory
     /**
      * Creates a request using a simplified array of options.
      *
-     * @param  null|string  $method
-     * @param  null|string  $uri
-     * @param  array        $options
+     * @param  null|string $method
+     * @param  null|string $uri
+     * @param  array       $options
      * @return Request
      */
     public function getRequestWithOptions($method, $uri, array $options = [])

--- a/src/Util/UrlHelpersTrait.php
+++ b/src/Util/UrlHelpersTrait.php
@@ -8,12 +8,12 @@ trait UrlHelpersTrait
     /**
      * Generate Client URL for specified username.
      *
-     * @param  string  $username
-     * @param  string  $domainId
+     * @param  string $username
+     * @param  string $domainId
      * @return string
-     * @throws \InvalidArgumentEception
+     * @throws InvalidArgumentException
      */
-    public function clientUrl($username, $domainId)
+    public function clientUrl(string $username, string $domainId)
     {
         if (is_null($this->urlClient)) {
             throw new InvalidArgumentException(
@@ -41,13 +41,13 @@ trait UrlHelpersTrait
     /**
      * Generate Console URL for specified username owning the virtual machine.
      *
-     * @param  string  $username
-     * @param  string  $domainId
-     * @param  string  $virtualMachineId
+     * @param  string $username
+     * @param  string $domainId
+     * @param  string $virtualMachineId
      * @return string
-     * @throws \InvalidArgumentEception
+     * @throws InvalidArgumentException
      */
-    public function consoleUrl($username, $domainId, $virtualMachineId)
+    public function consoleUrl(string $username, string $domainId, string $virtualMachineId)
     {
         if (is_null($this->urlConsole)) {
             throw new InvalidArgumentException(

--- a/src/Util/UrlHelpersTrait.php
+++ b/src/Util/UrlHelpersTrait.php
@@ -35,7 +35,7 @@ trait UrlHelpersTrait
         $method  = $this->getCommandMethod($command);
         $query   = $this->enableSso()->getCommandQuery($params);
 
-        return $this->urlClient.'?loginUrl='.urlencode($query);
+        return $this->urlClient . '?loginUrl=' . urlencode($query);
     }
 
     /**


### PR DESCRIPTION
* Added PHPStan to testing pipeline
* Made testing pipeline available through `composer test`
* Enforced a stricter ruleset for PHPCS (added PSR1 & PHPDoc rules)
* Fixed argument typehints
* Fixed faulty return types
* Fixed docblocks
* Upgraded supported PHP version to 7.1
* Dropped support for HHVM
* Included PSR12 (draft) in to codestyle requirements