### PR TITLE
Stricter Typing

### DIFF
--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PCextreme\Cloudstack;
 
 use GuzzleHttp\Client as HttpClient;
@@ -63,9 +65,9 @@ abstract class AbstractClient
      * Return the list of options that can be passed to the HttpClient
      *
      * @param  array $options
-     * @return string[]
+     * @return array
      */
-    protected function getAllowedClientOptions(array $options)
+    protected function getAllowedClientOptions(array $options) : array
     {
         $clientOptions = ['timeout', 'proxy'];
 
@@ -85,7 +87,7 @@ abstract class AbstractClient
      * @param  array  $options
      * @return RequestInterface
      */
-    public function getRequest(string $method, string $url, array $options = [])
+    public function getRequest(string $method, string $url, array $options = []) : RequestInterface
     {
         return $this->createRequest($method, $url, $options);
     }
@@ -98,7 +100,7 @@ abstract class AbstractClient
      * @param  array  $options
      * @return RequestInterface
      */
-    protected function createRequest(string $method, string $url, array $options)
+    protected function createRequest(string $method, string $url, array $options) : RequestInterface
     {
         $factory = $this->getRequestFactory();
 
@@ -111,7 +113,7 @@ abstract class AbstractClient
      * @param  RequestInterface $request
      * @return ResponseInterface
      */
-    protected function sendRequest(RequestInterface $request)
+    protected function sendRequest(RequestInterface $request) : ResponseInterface
     {
         try {
             $response = $this->getHttpClient()->send($request);
@@ -145,7 +147,7 @@ abstract class AbstractClient
      * @return array
      * @throws UnexpectedValueException
      */
-    protected function parseJson(string $content)
+    protected function parseJson(string $content) : array
     {
         $content = json_decode($content, true);
 
@@ -165,7 +167,7 @@ abstract class AbstractClient
      * @param  ResponseInterface $response
      * @return string
      */
-    protected function getContentType(ResponseInterface $response)
+    protected function getContentType(ResponseInterface $response) : string
     {
         return join(';', (array) $response->getHeader('content-type'));
     }
@@ -217,7 +219,7 @@ abstract class AbstractClient
      * @param  RequestFactory $factory
      * @return self
      */
-    public function setRequestFactory(RequestFactory $factory)
+    public function setRequestFactory(RequestFactory $factory) : self
     {
         $this->requestFactory = $factory;
 
@@ -229,7 +231,7 @@ abstract class AbstractClient
      *
      * @return RequestFactory
      */
-    public function getRequestFactory()
+    public function getRequestFactory() : RequestFactory
     {
         return $this->requestFactory;
     }
@@ -240,7 +242,7 @@ abstract class AbstractClient
      * @param  HttpClientInterface $client
      * @return self
      */
-    public function setHttpClient(HttpClientInterface $client)
+    public function setHttpClient(HttpClientInterface $client) : self
     {
         $this->httpClient = $client;
 
@@ -252,7 +254,7 @@ abstract class AbstractClient
      *
      * @return HttpClientInterface
      */
-    public function getHttpClient()
+    public function getHttpClient() : HttpClientInterface
     {
         return $this->httpClient;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PCextreme\Cloudstack;
 
 use InvalidArgumentException;
@@ -96,7 +98,7 @@ class Client extends AbstractClient
      *
      * @return array
      */
-    protected function getConfigurableOptions()
+    protected function getConfigurableOptions() : array
     {
         return array_merge($this->getRequiredOptions(), [
             'apiList',
@@ -113,7 +115,7 @@ class Client extends AbstractClient
      *
      * @return array
      */
-    protected function getRequiredOptions()
+    protected function getRequiredOptions() : array
     {
         return [
             'urlApi',
@@ -129,7 +131,7 @@ class Client extends AbstractClient
      * @return void
      * @throws InvalidArgumentException
      */
-    private function assertRequiredOptions(array $options)
+    private function assertRequiredOptions(array $options) : void
     {
         $missing = array_diff_key(array_flip($this->getRequiredOptions()), $options);
 
@@ -167,7 +169,7 @@ class Client extends AbstractClient
      * @throws RuntimeException
      * @throws InvalidArgumentException
      */
-    private function assertRequiredCommandOptions(string $command, array $options = [])
+    private function assertRequiredCommandOptions(string $command, array $options = []) : void
     {
         $apiList = $this->getApiList();
 
@@ -192,7 +194,7 @@ class Client extends AbstractClient
      * @param  string $command
      * @return string
      */
-    public function getCommandMethod(string $command)
+    public function getCommandMethod(string $command) : string
     {
         if (in_array($command, ['login', 'deployVirtualMachine'])) {
             return self::METHOD_POST;
@@ -207,7 +209,7 @@ class Client extends AbstractClient
      * @param  array $params
      * @return string
      */
-    public function getCommandQuery(array $params)
+    public function getCommandQuery(array $params) : string
     {
         return $this->signCommandParameters($params);
     }
@@ -219,7 +221,7 @@ class Client extends AbstractClient
      * @param  array  $options
      * @return string
      */
-    public function getCommandUrl(string $command, array $options = [])
+    public function getCommandUrl(string $command, array $options = []) : string
     {
         $base   = $this->urlApi;
         $params = $this->getCommandParameters($command, $options);
@@ -235,7 +237,7 @@ class Client extends AbstractClient
      * @param  array  $options
      * @return array
      */
-    protected function getCommandParameters(string $command, array $options)
+    protected function getCommandParameters(string $command, array $options) : array
     {
         return array_merge($options, [
             'command'  => $command,
@@ -250,7 +252,7 @@ class Client extends AbstractClient
      * @param  array $params
      * @return string
      */
-    protected function signCommandParameters(array $params = [])
+    protected function signCommandParameters(array $params = []) : string
     {
         if ($this->isSsoEnabled() && is_null($this->ssoKey)) {
             throw new InvalidArgumentException(
@@ -287,7 +289,7 @@ class Client extends AbstractClient
      * @return array
      * @throws RuntimeException
      */
-    public function getApiList()
+    public function getApiList() : array
     {
         if (is_null($this->apiList)) {
             $path = __DIR__.'/../cache/api_list.php';
@@ -310,7 +312,7 @@ class Client extends AbstractClient
      * @param  array $apiList
      * @return void
      */
-    public function setApiList(array $apiList)
+    public function setApiList(array $apiList) : void
     {
         $this->apiList = $apiList;
     }
@@ -322,7 +324,7 @@ class Client extends AbstractClient
      * @param  string $query
      * @return string
      */
-    protected function appendQuery(string $url, string $query)
+    protected function appendQuery(string $url, string $query) : string
     {
         $query = trim($query, '?&');
 
@@ -339,7 +341,7 @@ class Client extends AbstractClient
      * @param  array $params
      * @return string
      */
-    protected function buildQueryString(array $params)
+    protected function buildQueryString(array $params) : string
     {
         // We need to modify the nested array keys to get them accepted by Cloudstack.
         // For example 'details[0][key]' should resolve to 'details[0].key'.
@@ -375,7 +377,7 @@ class Client extends AbstractClient
      * @param  array $params
      * @return array
      */
-    protected static function flattenParams(array $params)
+    protected static function flattenParams(array $params) : array
     {
         $result = [];
 
@@ -398,7 +400,7 @@ class Client extends AbstractClient
      * @return void
      * @throws ClientException
      */
-    protected function checkResponse(ResponseInterface $response, $data)
+    protected function checkResponse(ResponseInterface $response, $data) : void
     {
         // Cloudstack returns multidimensional responses, keyed with the
         // command name. To handle errors in a generic way we need to 'reset'
@@ -420,7 +422,7 @@ class Client extends AbstractClient
      * @param  boolean $enable
      * @return self
      */
-    public function enableSso(bool $enable = true)
+    public function enableSso(bool $enable = true) : self
     {
         $this->ssoEnabled = $enable;
 
@@ -431,7 +433,7 @@ class Client extends AbstractClient
      *
      * @return boolean
      */
-    public function isSsoEnabled()
+    public function isSsoEnabled() : bool
     {
         return $this->ssoEnabled;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -343,7 +343,7 @@ class Client extends AbstractClient
     {
         // We need to modify the nested array keys to get them accepted by Cloudstack.
         // For example 'details[0][key]' should resolve to 'details[0].key'.
-        array_walk($params, function(&$value, $key) {
+        array_walk($params, function (&$value, $key) {
             if (is_array($value)) {
                 $parsedParams = [];
 
@@ -362,7 +362,7 @@ class Client extends AbstractClient
         // to encode the values, but we can't encode the keys. This would otherwise
         // compromise the signature. Therefore we can't use http_build_query().
         $queryParams = $this->flattenParams($params);
-        array_walk($queryParams, function(&$value, $key) {
+        array_walk($queryParams, function (&$value, $key) {
             $value = $key.'='.rawurlencode($value);
         });
 

--- a/src/Console/ApiListCommand.php
+++ b/src/Console/ApiListCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PCextreme\Cloudstack\Console;
 
 use PCextreme\Cloudstack\Client;
@@ -30,7 +32,7 @@ class ApiListCommand extends Command
      * @param  OutputInterface $output
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : void
     {
         $urlApi    = $this->askUrlApi($input, $output);
         $apiKey    = $this->askApiKey($input, $output);
@@ -71,7 +73,7 @@ class ApiListCommand extends Command
      * @param  OutputInterface $output
      * @return string
      */
-    protected function askUrlApi(InputInterface $input, OutputInterface $output)
+    protected function askUrlApi(InputInterface $input, OutputInterface $output) : string
     {
         $question = new Question(
             'Enter target API url [default: https://api.auroracompute.eu/ams]: ',
@@ -88,7 +90,7 @@ class ApiListCommand extends Command
      * @param  OutputInterface $output
      * @return string
      */
-    protected function askApiKey(InputInterface $input, OutputInterface $output)
+    protected function askApiKey(InputInterface $input, OutputInterface $output) : string
     {
         $question = (new Question('Enter API key: '))
             ->setValidator(function ($answer) {
@@ -110,7 +112,7 @@ class ApiListCommand extends Command
      * @param  OutputInterface $output
      * @return string
      */
-    protected function askSecretKey(InputInterface $input, OutputInterface $output)
+    protected function askSecretKey(InputInterface $input, OutputInterface $output) : string
     {
         $question = (new Question('Enter secret key: '))
             ->setValidator(function ($answer) {
@@ -132,7 +134,7 @@ class ApiListCommand extends Command
      * @param  array           $list
      * @return void
      */
-    protected function processList(OutputInterface $output, array $list = [])
+    protected function processList(OutputInterface $output, array $list = []) : void
     {
         if (empty($list)) {
             throw new \RuntimeException("API list is empty.");

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PCextreme\Cloudstack\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
@@ -30,7 +32,7 @@ class Application extends BaseApplication
      *
      * @return string A help message
      */
-    public function getHelp()
+    public function getHelp() : string
     {
         return self::$logo . parent::getHelp();
     }
@@ -40,7 +42,7 @@ class Application extends BaseApplication
      *
      * @return array
      */
-    protected function getDefaultCommands()
+    protected function getDefaultCommands() : array
     {
         $commands = array_merge(parent::getDefaultCommands(), [
             new ApiListCommand(),

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PCextreme\Cloudstack\Exception;
 
 use Exception;
@@ -26,6 +28,7 @@ class ClientException extends Exception
 
     /**
      * Returns the exception's response body.
+     * @TODO: Refactor this method, so that it returns a single type.
      *
      * @return array|string
      */

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PCextreme\Cloudstack;
 
 use GuzzleHttp\Psr7\Request;
@@ -28,7 +30,7 @@ class RequestFactory
         array $headers = [],
         $body = null,
         string $version = '1.1'
-    ) {
+    ) : Request {
         return new Request($method, $uri, $headers, $body, $version);
     }
 
@@ -38,7 +40,7 @@ class RequestFactory
      * @param  array $options
      * @return array
      */
-    protected function parseOptions(array $options)
+    protected function parseOptions(array $options) : array
     {
         // Should match default values for getRequest
         $defaults = [
@@ -58,7 +60,7 @@ class RequestFactory
      * @param  array       $options
      * @return Request
      */
-    public function getRequestWithOptions($method, $uri, array $options = [])
+    public function getRequestWithOptions($method, $uri, array $options = []) : Request
     {
         $options = $this->parseOptions($options);
 

--- a/src/Util/UrlHelpersTrait.php
+++ b/src/Util/UrlHelpersTrait.php
@@ -1,4 +1,8 @@
-<?php namespace PCextreme\Cloudstack\Util;
+<?php
+
+declare(strict_types=1);
+
+namespace PCextreme\Cloudstack\Util;
 
 use InvalidArgumentException;
 use PCextreme\Cloudstack\Exception\ClientException;
@@ -13,7 +17,7 @@ trait UrlHelpersTrait
      * @return string
      * @throws InvalidArgumentException
      */
-    public function clientUrl(string $username, string $domainId)
+    public function clientUrl(string $username, string $domainId) : string
     {
         if (is_null($this->urlClient)) {
             throw new InvalidArgumentException(
@@ -47,7 +51,7 @@ trait UrlHelpersTrait
      * @return string
      * @throws InvalidArgumentException
      */
-    public function consoleUrl(string $username, string $domainId, string $virtualMachineId)
+    public function consoleUrl(string $username, string $domainId, string $virtualMachineId) : string
     {
         if (is_null($this->urlConsole)) {
             throw new InvalidArgumentException(

--- a/test/src/AbstractClientTest.php
+++ b/test/src/AbstractClientTest.php
@@ -10,6 +10,7 @@ use PCextreme\Cloudstack\Exception\ClientException;
 use PCextreme\Cloudstack\RequestFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\StreamInterface;
 
 use Mockery as m;
@@ -85,14 +86,15 @@ class AbstractClientTest extends \PHPUnit_Framework_TestCase
     public function testGetRequest()
     {
         $mockAdapter = m::mock(RequestFactory::class);
-        $mockAdapter->shouldReceive('getRequestWithOptions')->andReturn([]);
+        $mockRequest = new Request('GET', '/test/uri');
+        $mockAdapter->shouldReceive('getRequestWithOptions')->andReturn($mockRequest);
 
         $client = new MockClient([], ['requestFactory' => $mockAdapter]);
 
         $method = $this->getMethod(MockClient::class, 'getRequest');
         $request = $method->invokeArgs($client, ['GET', 'mock-url', []]);
 
-        $this->assertSame([], $request);
+        $this->assertSame($mockRequest, $request);
     }
 
     public function testSendRequestSuccess()


### PR DESCRIPTION
Implements PHP return types where possible.

Enforces strict types on all classes, this means that typehints now throw a TypeError when a value doesn't match the typehint type. Before this PR those values where attempted to be casted.