### PR TITLE
Bump PHPUnit version from 5.x to 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "infection/infection": "^0.10.5",
         "mockery/mockery": "~0.9",
         "phpstan/phpstan": "^0.10.3",
-        "phpunit/phpunit": "~5.0",
+        "phpunit/phpunit": "~7.0",
         "satooshi/php-coveralls": "^2.0",
         "squizlabs/php_codesniffer": "~3.3"
     },

--- a/test/src/AbstractClientTest.php
+++ b/test/src/AbstractClientTest.php
@@ -11,10 +11,11 @@ use PCextreme\Cloudstack\RequestFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 use Mockery as m;
 
-class AbstractClientTest extends \PHPUnit_Framework_TestCase
+class AbstractClientTest extends TestCase
 {
     public function tearDown()
     {

--- a/test/src/ClientTest.php
+++ b/test/src/ClientTest.php
@@ -5,10 +5,11 @@ namespace PCextreme\Cloudstack\Test;
 use PCextreme\Cloudstack\Client;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 use Mockery as m;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @var AbstractClient

--- a/test/src/Console/ApplicationTest.php
+++ b/test/src/Console/ApplicationTest.php
@@ -3,8 +3,9 @@
 namespace PCextreme\Cloudstack\Test\Console;
 
 use PCextreme\Cloudstack\Console\Application;
+use PHPUnit\Framework\TestCase;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     /**
      * @var string

--- a/test/src/Exception/ClientExceptionTest.php
+++ b/test/src/Exception/ClientExceptionTest.php
@@ -3,8 +3,9 @@
 namespace PCextreme\Cloudstack\Test\Exception;
 
 use PCextreme\Cloudstack\Exception\ClientException;
+use PHPUnit\Framework\TestCase;
 
-class ClientExceptionTest extends \PHPUnit_Framework_TestCase
+class ClientExceptionTest extends TestCase
 {
     /**
      * @var array

--- a/test/src/RequestFactoryTest.php
+++ b/test/src/RequestFactoryTest.php
@@ -4,9 +4,11 @@ namespace PCextreme\Cloudstack\Test;
 
 use PCextreme\Cloudstack\RequestFactory;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
+
 use Mockery as m;
 
-class RequestFactoryTest extends \PHPUnit_Framework_TestCase
+class RequestFactoryTest extends TestCase
 {
     /**
      * @var RequestFactory


### PR DESCRIPTION
We kept getting [PHP_Warnings in our CI](https://travis-ci.org/PCextreme/cloudstack-php/jobs/444589832#L546) caused by an outdated version of phpunit/php-code-coverage.

This has been resolved by bumping the phpunit/phpunit version from 5.x to 7.x

One change that needed to be made: the PHPUnit_Testcase namespace. This has been updated in the codebase.