### PR TITLE
Disabled identical-equal and not-identical-not-equal mutators

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -7,5 +7,10 @@
     },
     "logs": {
         "text": "build/logs/infection-log.txt"
+    },
+    "mutators": {
+        "@default": true,
+        "IdenticalEqual": false,
+        "NotIdenticalNotEqual": false
     }
 }


### PR DESCRIPTION
We can disable them. Since we use `===` everywhere, these mutators are obsolete.