### PR TITLE
Fixed coveralls binary name in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
   - composer run test
 
 after_script:
-  - php vendor/bin/coveralls
+  - php vendor/bin/php-coveralls


### PR DESCRIPTION
Ever since (fa1f765) coveralls was broken in our TravisCI pipeline, this was caused by a BC break in coveralls between version 0.x and 2.x. 

This PR fixes that BC break. Coveralls shall once again record our coverage.